### PR TITLE
mysql limit clause PDO

### DIFF
--- a/database/mysql_limit_clause.php
+++ b/database/mysql_limit_clause.php
@@ -1,0 +1,39 @@
+
+< ? php try { 
+    $pdo = new PDO("mysql:host=localhost;dbname=Mydb", "root", ""); 
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION); 
+} 
+catch (PDOException $e) { 
+    die("ERROR: Could not connect. ".$e->getMessage()); 
+} 
+  
+try { 
+    $sql = "SELECT * FROM Data LIMIT 2"; 
+    $res = $pdo->query($sql); 
+    if ($res->rowCount() > 0) { 
+        echo "<table>"; 
+        echo "<tr>"; 
+        echo "<th>Firstname</th>"; 
+        echo "<th>Lastname</th>"; 
+        echo "<th>Age</th>"; 
+        echo "</tr>"; 
+        while ($row = $res->fetch()) { 
+            echo "<tr>"; 
+            echo "<td>".$row['Firstname']."</td>"; 
+            echo "<td>".$row['Lastname']."</td>"; 
+            echo "<td>".$row['Age']."</td>"; 
+            echo "</tr>"; 
+        } 
+        echo "</table>"; 
+        unset($res); 
+    } 
+    else { 
+        echo "No matching records are found."; 
+    } 
+} 
+catch (PDOException $e) { 
+    die("ERROR: Could not able to execute $sql. ".$e->getMessage()); 
+} 
+  
+unset($pdo); 
+? > 


### PR DESCRIPTION
In MySQL the LIMIT clause is used with the SELECT statement to restrict the number of rows in the result set. The Limit Clause accepts one or two arguments which are offset and count.The value of both the parameters can be zero or positive integers.